### PR TITLE
add Zenodo-minted DOI badge to the README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GeoPandas Demo
 
+[![DOI](https://zenodo.org/badge/140001231.svg)](https://zenodo.org/badge/latestdoi/140001231)
+
 This repository contains a Jupyter notebook that demonstrates some of the
 GIS-like functionality of the GeoPandas Python library.  It uses data from the
 British Geological Survey's [earthquake catalogue](http://earthquakes.bgs.ac.uk/earthquakes/dataSearch.html) and the public domain [Natural Earth](http://www.naturalearthdata.com) project to calculate the towns in the UK that feel the most earthquakes.


### PR DESCRIPTION
- remember it will change with each release so this would need updating

Zenodo is now enabled for the group, but before cutting a release for a project, you still have to explicitly enable that individual project via a toggle in Zenodo (log in there via GitHub)

https://guides.github.com/activities/citable-code/#login

